### PR TITLE
Add Windows layout after install

### DIFF
--- a/docs/tutorials/install/layout.rst
+++ b/docs/tutorials/install/layout.rst
@@ -67,26 +67,26 @@ Windows layout after installation of
 
 .. code-block:: none
 
-├── bin/
-│   ├── fruits_breakfast.exe
-│   └── fruits_dinner.exe
-├── include/
-│   └── fruits/
-│       ├── fruits.hpp
-│       ├── rosaceae/
-│       │   ├── Pear.hpp
-│       │   ├── Plum.hpp
-│       │   └── rosaceae.hpp
-│       └── tropical/
-│           ├── Avocado.hpp
-│           ├── Pineapple.hpp
-│           └── tropical.hpp
-└── lib/
-    ├── cmake/
-    │   └── fruits/
-    │       ├── fruitsConfig.cmake
-    │       ├── fruitsConfigVersion.cmake
-    │       ├── fruitsTargets.cmake
-    │       └── fruitsTargets-release.cmake
-    ├── fruits_rosaceae.lib
-    └── fruits_tropical.lib
+  ├── bin/
+  │   ├── fruits_breakfast.exe
+  │   └── fruits_dinner.exe
+  ├── include/
+  │   └── fruits/
+  │       ├── fruits.hpp
+  │       ├── rosaceae/
+  │       │   ├── Pear.hpp
+  │       │   ├── Plum.hpp
+  │       │   └── rosaceae.hpp
+  │       └── tropical/
+  │           ├── Avocado.hpp
+  │           ├── Pineapple.hpp
+  │           └── tropical.hpp
+  └── lib/
+      ├── cmake/
+      │   └── fruits/
+      │       ├── fruitsConfig.cmake
+      │       ├── fruitsConfigVersion.cmake
+      │       ├── fruitsTargets.cmake
+      │       └── fruitsTargets-release.cmake
+      ├── fruits_rosaceae.lib
+      └── fruits_tropical.lib

--- a/docs/tutorials/install/layout.rst
+++ b/docs/tutorials/install/layout.rst
@@ -61,3 +61,32 @@ Linux layout after installation of
       │       └── fruitsTargets-release.cmake
       ├── libfruits_rosaceae.a
       └── libfruits_tropical.a
+
+Windows layout after installation of
+`example project <https://github.com/cgold-examples/fruits>`__:
+
+.. code-block:: none
+
+├── bin/
+│   ├── fruits_breakfast.exe
+│   └── fruits_dinner.exe
+├── include/
+│   └── fruits/
+│       ├── fruits.hpp
+│       ├── rosaceae/
+│       │   ├── Pear.hpp
+│       │   ├── Plum.hpp
+│       │   └── rosaceae.hpp
+│       └── tropical/
+│           ├── Avocado.hpp
+│           ├── Pineapple.hpp
+│           └── tropical.hpp
+└── lib/
+    ├── cmake/
+    │   └── fruits/
+    │       ├── fruitsConfig.cmake
+    │       ├── fruitsConfigVersion.cmake
+    │       ├── fruitsTargets.cmake
+    │       └── fruitsTargets-release.cmake
+    ├── fruits_rosaceae.lib
+    └── fruits_tropical.lib


### PR DESCRIPTION
I though it would be useful to people trying to figure out exactly what changes in the install layout on the different platforms.

I took the Windows layout from the appveyor run so it is correct :-)

Feel free to edit and/or squash.