### PR TITLE
fix odb-global example

### DIFF
--- a/docs/tutorials/libraries/symbols/odr-global.rst
+++ b/docs/tutorials/libraries/symbols/odr-global.rst
@@ -131,6 +131,6 @@ put the code under ``if`` condition:
 
   if(NOT EXISTS "${CMAKE_TOOLCHAIN_FILE}")
     set(CMAKE_CXX_STANDARD 11)
-    set_target_properties(boo PROPERTIES CXX_STANDARD 14)
+    set_target_properties(boo PROPERTIES CXX_STANDARD 11)
     # ...
   endif()

--- a/docs/tutorials/libraries/symbols/odr-global.rst
+++ b/docs/tutorials/libraries/symbols/odr-global.rst
@@ -125,7 +125,8 @@ global nature, it might be helpful to set all such properties/flags in one
 place - :doc:`toolchain </tutorials/toolchain>`.
 
 If you still want to set global flags locally for any reason then at least
-put the code under ``if`` condition:
+put the code under ``if`` condition. For example let's set C++11 for
+all targets in the project and C++14 for target ``boo``:
 
 .. code-block:: cmake
 

--- a/docs/tutorials/libraries/symbols/odr-global.rst
+++ b/docs/tutorials/libraries/symbols/odr-global.rst
@@ -130,7 +130,7 @@ put the code under ``if`` condition:
 .. code-block:: cmake
 
   if(NOT EXISTS "${CMAKE_TOOLCHAIN_FILE}")
-    set(CMAKE_CXX_STANDARD 11)
-    set_target_properties(boo PROPERTIES CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 11) # set a global minimum standard
+    set_target_properties(boo PROPERTIES CXX_STANDARD 14) # set a standard for a target
     # ...
   endif()


### PR DESCRIPTION
in whole example c++11 is used, but in the last property c++14 was used