### PR TITLE
fix if STREQUAL typo

### DIFF
--- a/docs/tutorials/control-structures.rst
+++ b/docs/tutorials/control-structures.rst
@@ -156,7 +156,7 @@ To avoid such issues you should use CMake 3.1 and ``CMP0054`` policy:
 Workaround
 ~~~~~~~~~~
 
-For CMake before 3.1 as a workaround you can use ``string(... STREQUAL ...)``
+For CMake before 3.1 as a workaround you can use ``string(COMPARE EQUAL ...)``
 command:
 
 .. literalinclude:: /examples/control-structures/cmp0054-workaround/CMakeLists.txt


### PR DESCRIPTION
in the workaround for `if(... STREQUAL ...)` the cmake function `string(... STREQUAL ...)` is proposed. But the real call is `string(COMPARE EQUAL ...)`