### PR TITLE
add link to vs2017 download

### DIFF
--- a/docs/first-step/native-build-tool/visual-studio.rst
+++ b/docs/first-step/native-build-tool/visual-studio.rst
@@ -4,9 +4,9 @@
 Visual Studio
 =============
 
-``Visual Studio`` is an IDE created by ``Microsoft``. Here are the links to the
-``*.iso`` images of community versions:
+``Visual Studio`` is an IDE created by ``Microsoft``. Here are the links to the community versions:
 
+* `Visual Studio Community 2017 <https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community>`__ 
 * `Visual Studio Community 2015 <https://go.microsoft.com/fwlink/?LinkId=615448&clcid=0x409>`__ 
 * `Visual Studio Community 2013 <https://go.microsoft.com/fwlink/?LinkId=532496&type=ISO&clcid=0x409>`__
 


### PR DESCRIPTION
Older versions should be dropped, IMO. The 2017 is a web installer. Microsoft doesn't offer full downloads.