### PR TITLE
Document the 3.13 explicit source directories

### DIFF
--- a/docs/glossary/-B.rst
+++ b/docs/glossary/-B.rst
@@ -14,7 +14,16 @@ Path to this directory will be saved in
 `CMAKE_BINARY_DIR <https://cmake.org/cmake/help/latest/variable/CMAKE_BINARY_DIR.html>`__
 variable.
 
+.. note::
+Starting with CMake 3.13,  ``-B`` is an officially supported flag and can handle
+spaces correctly and can be used independently of the :ref:`-S <-S>` or :ref:`-H <-H>` options.
+
+.. code-block:: none
+
+  cmake -B _builds .
+
 .. seealso::
 
   * :ref:`Binary tree <binary tree>`
+  * :ref:`-S <-S>`
   * :ref:`-H <-H>`

--- a/docs/glossary/-H.rst
+++ b/docs/glossary/-H.rst
@@ -10,6 +10,10 @@
 -H
 --
 
+.. note::
+
+  Has been replaced in 3.13 with the official source directory flag of :ref:`-S <-S>`.
+
 Add ``-H<path-to-source-tree>`` to set directory with ``CMakeLists.txt``.
 This internal option is not documented but
 `widely used by community <https://github.com/search?q=%22cmake+-H%22&ref=searchresults&type=Code&utf8=%E2%9C%93>`__.
@@ -39,6 +43,7 @@ variable.
 
 .. seealso::
 
+  * :ref:`-S <-S>`
   * :ref:`-B <-B>`
   * :ref:`Source tree <source tree>`
 

--- a/docs/glossary/-S.rst
+++ b/docs/glossary/-S.rst
@@ -1,0 +1,39 @@
+.. Copyright (c) 2016-2017, Ruslan Baratov
+.. All rights reserved.
+
+.. spelling::
+
+  PowerShell
+
+.. _-S:
+
+-S
+--
+
+Add ``-S <path-to-source-tree>`` to set directory with ``CMakeLists.txt``.
+This option was added in CMake 3.13 and replaces the the undocumented and internal variable ``-H``. This option can be used independently of ``-B``.
+
+.. code-block:: none
+
+  cmake -S . -B _builds
+
+Use current directory as a source tree (i.e. start with
+``./CMakeLists.txt``) and put generated files to the ``./_builds`` folder.
+
+Path to this directory will be saved in
+`CMAKE_SOURCE_DIR <https://cmake.org/cmake/help/latest/variable/CMAKE_SOURCE_DIR.html>`__
+variable.
+
+.. warning::
+
+  PowerShell will modify arguments and put the space between ``-S`` and ``.``.
+  You can protect argument by quoting it:
+
+  .. code-block:: none
+
+    cmake '-S.' -B_builds
+
+.. seealso::
+
+  * :ref:`-B <-B>`
+  * :ref:`Source tree <source tree>`


### PR DESCRIPTION
In preparation for the 3.13 release I want to update the CGold documentation on the `-H` and `-B` flags as CMake now has support for explicit source and build directories with `-S` and `-B`.

Changes:
https://gitlab.kitware.com/cmake/cmake/merge_requests/2358/diffs

Note: I did the editing locally and didn't verify the rst is valid.